### PR TITLE
Add repo tag to the IMAGE name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ db:
   environment:
     - MYSQL_ROOT_PASSWORD=my-super-secret-password
 web:
-  image: openxpki:latest
+  image: dime/openxpki:latest
   dns: 8.8.8.8
   hostname: pki.example.org
   restart: always


### PR DESCRIPTION
Using your docker compose file from my machine need to pull your image from your repo with full image tag name - "dime/openxpki:latest" instead of "openxpki:latest".